### PR TITLE
add better rvm status line detecting

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -1,3 +1,4 @@
+set verbose=0
 set nocompatible
 filetype off
 
@@ -111,8 +112,11 @@ if has("statusline") && !&cp
 
   " Add rvm
   if exists('$rvm_path')
-    set statusline+=%{rvm#statusline()}
+   if exists('*rvm#statusline')
+     set statusline+=%{rvm#statusline()}
+   end
   endif
+  "
   " Add fugitive
   set statusline+=%{fugitive#statusline()}
 


### PR DESCRIPTION
Add better rvm status line detecting.
Now it checks not only existence $rvm_path, but rvm#statusline function as well. I does not crush anymore if rvm-vim is not installed